### PR TITLE
fix for pypi - support install from sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ target/
 /.settings/
 /.pydevproject
 /.vscode
+/.history
 
 # DLS build dir and virtual environment
 /prefix/

--- a/versiongit/_version_git.py
+++ b/versiongit/_version_git.py
@@ -47,7 +47,13 @@ def get_version_from_git(path=None):
     return tag, error, sha1
 
 
-__version__, git_error, git_sha1 = get_version_from_git()
+try:
+    # When installing from sdist there will already be a _version_static.py
+    # and during setup it will be on the python path (see setup.py: os.walk)
+    from _version_static import __version__  # type: ignore
+except ImportError:
+    # Otherwise get the release number from git describe
+    __version__, git_error, git_sha1 = get_version_from_git()
 
 
 def get_cmdclass(build_py=None, sdist=None):
@@ -63,6 +69,11 @@ def get_cmdclass(build_py=None, sdist=None):
         pkg = pkg.split(".")[0]
         with open(os.path.join(base_dir, pkg, "_version_static.py"), "w") as f:
             f.write("__version__ = %r\n" % __version__)
+        static_version = os.path.join(base_dir, pkg, "_version_static.py")
+        # when installing from sdist the _version_static.py will already exist
+        if not os.path.exists(static_version):
+            with open(static_version, "w") as f:
+                f.write("__version__ = %r\n" % __version__)
 
     class BuildPy(build_py):
         def run(self):


### PR DESCRIPTION
Hey, @thomascobb, I managed to get this to work.

You can verify it by looking at the latest dls-controls/test_versiongit.

The secret was that when doing pip install from an sdist, pip was running setup again to make a bdist (I'm not sure why, but that is what happens). I just needed some tweaks so that make_version_static coped with this.